### PR TITLE
Add new API: adjoininit

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -13,6 +13,7 @@ InitialValues.@disambiguate
 InitialValues.hasinitialvalue
 InitialValues.isknown
 InitialValues.InitialValue
+InitialValues.adjoininit
 InitialValues.asmonoid
 InitialValues.Initializer
 InitialValues.initialize

--- a/src/InitialValues.jl
+++ b/src/InitialValues.jl
@@ -450,15 +450,16 @@ asmonoid(op) = hasinitialvalue(op) ? op : AdjoinIdentity(op)
 hasinitialvalue(::Type{AdjoinIdentity{T}}) where {T} = true
 
 """
-    adjoininit(op) -> op′
+    adjoininit(rf) -> rf′
 
-Transform a binary function `op` to a function `op′` such that
-`hasinitialvalue(op′) === true`.  Do nothing if `op` already has a
+Transform a binary function `rf` (aka reducing function) to a function
+`rf′` that has an initial value; i.e., `rf′(Init(rf′), x) === x` and
+`hasinitialvalue(rf′) === true`.  Do nothing if `rf` already has a
 known initial value.
 
 This is equivalent to [`asmonoid`](@ref) by default.  Frameworks for
-composing `op` (e.g., Transducers.jl) may overload this function such
-that `op′` itself is not a monoid.
+composing `rf` (e.g., Transducers.jl) may overload this function such
+that `rf′` itself is not a monoid.
 
 # Examples
 ```jldoctest
@@ -484,6 +485,6 @@ julia> ans === xs  # `xs` is modified
 true
 ```
 """
-adjoininit(op) = asmonoid(op)
+adjoininit(rf) = asmonoid(rf)
 
 end # module

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -114,7 +114,10 @@ end
     @test hasinitialvalue(typeof(absmin))
     @test isknown(Init(absmin))
 
-    @test asmonoid(+) === +
+    @test asmonoid(absmin) === absmin
+    @test adjoininit(absmin.op) === adjoininit(absmin) === absmin
+    @test asmonoid(nothing) === adjoininit(nothing) !== nothing
+    @test asmonoid(+) === adjoininit(+) === +
 end
 
 @testset "initialize" begin


### PR DESCRIPTION
`asmonoid` was not a nice API for Transducers.jl to overload because `asmonoid(reducingfunction(xf, semigroup))` does not make sense (unless `xf` is an identity).  So, this PR defines an API `adjoininit` whose name does not imply that it returns a monoid.