### PR TITLE
Deprecate Init(op)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,9 @@ uuid = "22cec73e-a1b8-11e9-2c92-598750a2cf9c"
 authors = ["Takafumi Arakaki <aka.tkf@gmail.com>"]
 version = "0.2.8-DEV"
 
+[deps]
+Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+
 [compat]
 julia = "1.0"
 

--- a/README.md
+++ b/README.md
@@ -7,49 +7,49 @@
 [![Coveralls](https://coveralls.io/repos/github/JuliaFolds/InitialValues.jl/badge.svg?branch=master)](https://coveralls.io/github/JuliaFolds/InitialValues.jl?branch=master)
 [![Aqua QA](https://img.shields.io/badge/Aqua.jl-%F0%9F%8C%A2-aqua.svg)](https://github.com/tkf/Aqua.jl)
 
-InitialValues.jl provides a generic singleton initial value `Init(f)`
+InitialValues.jl provides a generic singleton initial value `InitialValue(f)`
 that can be used as `a₀` in `f(a₀, x)`.  For a binary operator `op`,
-it means that `Init(op)` acts like the identity for _any_ type of `x`:
+it means that `InitialValue(op)` acts like the identity for _any_ type of `x`:
 
 ```julia
 julia> using InitialValues
 
-julia> Init(+) + 1
+julia> InitialValue(+) + 1
 1
 
-julia> 1.0 + Init(+)
+julia> 1.0 + InitialValue(+)
 1.0
 
-julia> foldl(+, 1:3, init=Init(+))
+julia> foldl(+, 1:3, init=InitialValue(+))
 6
 ```
 
 Following methods are defined for the binary operators in `Base`:
 
 ```julia
-julia> Init(*) * 1
+julia> InitialValue(*) * 1
 1
 
-julia> Init(&) & 1
+julia> InitialValue(&) & 1
 1
 
-julia> Init(|) | 1
+julia> InitialValue(|) | 1
 1
 
-julia> min(Init(min), 1)
+julia> min(InitialValue(min), 1)
 1
 
-julia> max(Init(max), 1)
+julia> max(InitialValue(max), 1)
 1
 
-julia> Base.add_sum(Init(Base.add_sum), 1)
+julia> Base.add_sum(InitialValue(Base.add_sum), 1)
 1
 
-julia> Base.mul_prod(Init(Base.mul_prod), 1)
+julia> Base.mul_prod(InitialValue(Base.mul_prod), 1)
 1
 ```
 
-`Init` is not called `Identity` because it is useful to define it for
+`InitialValue` is not called `Identity` because it is useful to define it for
 functions that are not binary operator (symmetric in signature).  For
 example, `push!!` in [BangBang.jl](https://github.com/JuliaFolds/BangBang.jl)
 defines
@@ -57,7 +57,7 @@ defines
 ``````julia
 julia> using BangBang
 
-julia> push!!(Init(push!!), 1)
+julia> push!!(InitialValue(push!!), 1)
 1-element Array{Int64,1}:
  1
 ``````
@@ -65,7 +65,7 @@ julia> push!!(Init(push!!), 1)
 This provides a powerful pattern when combined with `foldl`:
 
 ``````julia
-julia> foldl(push!!, (1, missing, 2.0), init=Init(push!!))
+julia> foldl(push!!, (1, missing, 2.0), init=InitialValue(push!!))
 3-element Array{Union{Missing, Float64},1}:
  1.0
   missing
@@ -73,7 +73,7 @@ julia> foldl(push!!, (1, missing, 2.0), init=Init(push!!))
 ``````
 
 [Transducers.jl](https://github.com/JuliaFolds/Transducers.jl) extensively
-uses `Init`.
+uses `InitialValue`.
 
 As binary operators like `*` in `Base` are heavily overloaded,
 creating generic definitions such as above could have introduced

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -5,13 +5,12 @@
 
 ```@docs
 InitialValues
-InitialValues.Init
+InitialValues.InitialValue
 InitialValues.INIT
 InitialValues.@def
 InitialValues.@def_monoid
 InitialValues.@disambiguate
 InitialValues.hasinitialvalue
 InitialValues.isknown
-InitialValues.InitialValue
 InitialValues.asmonoid
 ```

--- a/src/InitialValues.jl
+++ b/src/InitialValues.jl
@@ -25,7 +25,7 @@ value (see `BangBang.push!!`).
 ```jldoctest
 julia> using InitialValues
 
-julia> InitialValues(*) isa InitialValues.InitialValue
+julia> InitialValue(*) isa InitialValues.InitialValue
 true
 
 julia> InitialValue(*) * 1

--- a/test/interop/test_bangbang.jl
+++ b/test/interop/test_bangbang.jl
@@ -2,18 +2,18 @@ module TestBangBang
 
 using Test
 using BangBang
-using InitialValues: Init, hasinitialvalue
+using InitialValues: InitialValue, hasinitialvalue
 
 @testset begin
     @test hasinitialvalue(push!!)
     @test hasinitialvalue(append!!)
-    @test push!!(Init(push!!), 1) == [1]
-    @test append!!(Init(append!!), [1]) == [1]
-    @test append!!([1], Init(append!!)) == [1]
+    @test push!!(InitialValue(push!!), 1) == [1]
+    @test append!!(InitialValue(append!!), [1]) == [1]
+    @test append!!([1], InitialValue(append!!)) == [1]
 end
 
 @testset "promote" begin
-    init = Init(+)
+    init = InitialValue(+)
     @test eltype(push!!([init], 0)) == Union{typeof(init),Int}
 end
 

--- a/test/test_basics.jl
+++ b/test/test_basics.jl
@@ -7,27 +7,27 @@ using InitialValues: isknown, hasinitialvalue
 OPS = [*, +, |, &, min, max, Base.add_sum, Base.mul_prod]
 
 @testset for op in OPS
-    @test op(Init(op), :anything) === :anything
-    @test op(:anything, Init(op)) === :anything
+    @test op(InitialValue(op), :anything) === :anything
+    @test op(:anything, InitialValue(op)) === :anything
     @test op(INIT, :anything) === :anything
     @test op(:anything, INIT) === :anything
     @test hasinitialvalue(op)
     @test hasinitialvalue(typeof(op))
-    @test isknown(Init(op))
+    @test isknown(InitialValue(op))
 end
 
 @testset "show" begin
     @testset "$desired" for (op, desired) in [
-        (+, "Init(+)"),
-        (*, "Init(*)"),
-        (|, "Init(|)"),
-        (&, "Init(&)"),
-        (min, "Init(min)"),
-        (max, "Init(max)"),
+        (+, "InitialValue(+)"),
+        (*, "InitialValue(*)"),
+        (|, "InitialValue(|)"),
+        (&, "InitialValue(&)"),
+        (min, "InitialValue(min)"),
+        (max, "InitialValue(max)"),
     ]
-        @test repr(Init(op); context=:limit => true) == desired
-        @test repr(Init(op)) == "InitialValues.$desired"
-        @test string(Init(op)) == "InitialValues.$desired"
+        @test repr(InitialValue(op); context=:limit => true) == desired
+        @test repr(InitialValue(op)) == "InitialValues.$desired"
+        @test string(InitialValue(op)) == "InitialValues.$desired"
     end
     @testset "INIT" begin
         @test repr(INIT; context=:limit => true) == "INIT"
@@ -44,29 +44,29 @@ end
 end
 
 @testset "missing" begin
-    @test min(Init(min), missing) === missing
-    @test max(Init(max), missing) === missing
+    @test min(InitialValue(min), missing) === missing
+    @test max(InitialValue(max), missing) === missing
 end
 
 @testset "promote" begin
     for op in OPS
-        T = typeof(Init(op))
+        T = typeof(InitialValue(op))
         @test promote_type(T, Val{0}) == Union{T,Val{0}}
     end
 end
 
 @testset "convert" begin
     @testset "float" begin
-        @test float(Init(+)) === 0.0
-        @test float(Init(*)) === 1.0
-        @test float(Init(Base.add_sum)) === 0.0
-        @test float(Init(Base.mul_prod)) === 1.0
+        @test float(InitialValue(+)) === 0.0
+        @test float(InitialValue(*)) === 1.0
+        @test float(InitialValue(Base.add_sum)) === 0.0
+        @test float(InitialValue(Base.mul_prod)) === 1.0
     end
     @testset "Integer" begin
-        @test Integer(Init(+)) === 0
-        @test Integer(Init(*)) === 1
-        @test Integer(Init(Base.add_sum)) === 0
-        @test Integer(Init(Base.mul_prod)) === 1
+        @test Integer(InitialValue(+)) === 0
+        @test Integer(InitialValue(*)) === 1
+        @test Integer(InitialValue(Base.add_sum)) === 0
+        @test Integer(InitialValue(Base.mul_prod)) === 1
     end
     @testset for T in [
         Int,
@@ -74,25 +74,25 @@ end
         Float64,
         Float32,
     ]
-        @test convert(T, Init(+))::T == 0
-        @test convert(T, Init(*))::T == 1
-        @test convert(T, Init(Base.add_sum))::T == 0
-        @test convert(T, Init(Base.mul_prod))::T == 1
+        @test convert(T, InitialValue(+))::T == 0
+        @test convert(T, InitialValue(*))::T == 1
+        @test convert(T, InitialValue(Base.add_sum))::T == 0
+        @test convert(T, InitialValue(Base.mul_prod))::T == 1
     end
 
-    @test convert(String, Init(*)) === ""
+    @test convert(String, InitialValue(*)) === ""
 end
 
 @testset "asmonoid" begin
     absmin = asmonoid() do a, b
         abs(a) < abs(b) ? a : b
     end
-    @test absmin(Init(absmin), Inf) === Inf
-    @test absmin(missing, Init(absmin)) === missing
-    @test absmin(Init(absmin), Init(absmin)) === Init(absmin)
+    @test absmin(InitialValue(absmin), Inf) === Inf
+    @test absmin(missing, InitialValue(absmin)) === missing
+    @test absmin(InitialValue(absmin), InitialValue(absmin)) === InitialValue(absmin)
     @test hasinitialvalue(absmin)
     @test hasinitialvalue(typeof(absmin))
-    @test isknown(Init(absmin))
+    @test isknown(InitialValue(absmin))
 
     @test asmonoid(+) === +
 

--- a/test/test_def.jl
+++ b/test/test_def.jl
@@ -1,7 +1,7 @@
 module TestDef
 
 using Test
-using InitialValues: Init, hasinitialvalue, isknown
+using InitialValues: InitialValue, hasinitialvalue, isknown
 
 module CleanNameSpace
     using InitialValues: @def, @disambiguate
@@ -15,9 +15,9 @@ end
     add = CleanNameSpace.add
     @test !isdefined(CleanNameSpace, :InitialValues)
     @test hasinitialvalue(add)
-    @test isknown(Init(add))
-    @test add(Init(add), :x) == "Got: :x"
-    @test add(Init(add), missing) === missing
+    @test isknown(InitialValue(add))
+    @test add(InitialValue(add), :x) == "Got: :x"
+    @test add(InitialValue(add), missing) === missing
 end
 
 module NonFunction
@@ -33,9 +33,9 @@ end
     add = NonFunction.add
     @test !(add isa Function)
     @test hasinitialvalue(add)
-    @test isknown(Init(add))
-    @test add(Init(add), :x) == :x
-    @test add(Init(add), missing) === missing
+    @test isknown(InitialValue(add))
+    @test add(InitialValue(add), :x) == :x
+    @test add(InitialValue(add), missing) === missing
 end
 
 end  # module

--- a/test/test_deprecated.jl
+++ b/test/test_deprecated.jl
@@ -1,0 +1,10 @@
+module TestDeprecated
+
+using Test
+using InitialValues
+
+@testset "Init" begin
+    @test_deprecated Init(+)
+end
+
+end  # module


### PR DESCRIPTION
## Commit Message
Deprecate `Init(op)` (#47)

Using `foldl(op, xf, collection; init = Init)` in Transducers.jl has
been very useful.  However, it requires a special handling of `Init`
because it is not in the "initializer" type hierarchy:

> ```julia
> initialize(::typeof(Init), op) = check_init(Init(op), Init, op)
> initialize(f::InitOf, op) = check_init(f(op), f, op)
> ```
> --- https://github.com/JuliaFolds/Transducers.jl/blob/e5bc17538f16a0cc2d89e128bc509b8b1efa6bfc/src/core.jl#L873-L874

A (failed) solution attempted was to move the initializer API to
InitialValues.jl:

https://github.com/JuliaFolds/InitialValues.jl/pull/35

However, it didn't work well because the initializer is tightly
coupled with `Transducers.start` API.  It looks like moving this to
Transducers.jl (or "FoldsBase.jl") would be better:

* https://github.com/JuliaFolds/InitialValues.jl/pull/37: revert #35
* https://github.com/JuliaFolds/Transducers.jl/pull/289#issuecomment-633291202:
  Explains the rationale to revert #35.

In order to treat `Init` in a unified "initializer" framework while
keeping InitialValues.jl self-contained, this PR starts the process of
removing `Init` from InitialValues.jl by deprecating it.  The new
interface is simply `InitialValue(op)`.  This is nice also because
`InitialValue(op) isa InitialValue` holds.

See also:
https://github.com/JuliaFolds/Transducers.jl/pull/341
(Refactoring initializer API; define `Init` in Transducers.jl)
